### PR TITLE
chore: remove gpl license from allowed list

### DIFF
--- a/github-actions/check-licenses/dist/index.js
+++ b/github-actions/check-licenses/dist/index.js
@@ -106,8 +106,7 @@ exports.ALLOWED_LICENSES = [
     "Public Domain",
     "Python-2.0",
     "Zope",
-    "WTFPL",
-    "GPL-2.0*"
+    "WTFPL"
 ];
 
 

--- a/github-actions/check-licenses/src/licenses.ts
+++ b/github-actions/check-licenses/src/licenses.ts
@@ -33,6 +33,5 @@ export const ALLOWED_LICENSES = [
   "Public Domain",
   "Python-2.0",
   "Zope",
-  "WTFPL",
-  "GPL-2.0*"
+  "WTFPL"
 ];


### PR DESCRIPTION
Removes GPL license from allowed list

Closes https://github.com/vuestorefront/engineering-toolkit/issues/11

**This PR will break CI in repos that already use Changesets. You will need to update the lockfile so that `breakword@1.0.6` is installed. 1.0.5 is still GPL licensed (bad) while MIT is 1.0.6**