### PR TITLE
chore(in-3337): turn off rules related to await and for loops

### DIFF
--- a/packages/integrations-eslint/index.js
+++ b/packages/integrations-eslint/index.js
@@ -49,7 +49,9 @@ module.exports = {
     "import/first": "warn",
     "no-empty": "warn",
     "import/no-dynamic-require": "warn",
-    "@typescript-eslint/no-var-requires": "warn"
+    "@typescript-eslint/no-var-requires": "warn",
+    "no-restricted-syntax": "off",
+    "no-await-in-loop": "off",
   },
   settings: {
     'import/resolver': {


### PR DESCRIPTION
### 🔗 [IN-3337](https://vsf.atlassian.net/browse/IN-3337)

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

There are two rules in that airbnb preset for eslint which I strongly dislike.

The first one disallows me to use a `for` loop in my code

<img width="1099" alt="image" src="https://github.com/vuestorefront/engineering-toolkit/assets/39009379/d0d3e76b-57bb-4a07-a570-1a1597eb4688">

The second one disallows me to use `await` inside my `for` loop:

<img width="547" alt="image" src="https://github.com/vuestorefront/engineering-toolkit/assets/39009379/19a86583-b6d2-4362-b573-a7a0af11d7d7">

However, there are use cases where I need to execute several async calls in a **sequence** (for whatever reason). As an alternative, I can use `Array.reduce()`:

```
urls.reduce(async (previousAxiosCall, url) => {
   await previousAxiosCall
   return axios.post(url)
}, Promise.resolve())
```

but come on... it's neither easy to write nor easy to read. We've already had a discussion about it on our [internal team channel](https://vsf-company.slack.com/archives/C057RV06JG0/p1690398001208829).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
