### PR TITLE
fix: unlocked TypeScript class methods overloading

### DIFF
--- a/.changeset/fair-apples-ring.md
+++ b/.changeset/fair-apples-ring.md
@@ -1,0 +1,5 @@
+---
+"@vue-storefront/eslint-config-integrations": patch
+---
+
+unlocked TypeScript class methods overloading

--- a/packages/integrations-eslint/index.js
+++ b/packages/integrations-eslint/index.js
@@ -61,5 +61,13 @@ module.exports = {
         extensions: ['.js', '.ts']
       }
     }
-  }
+  },
+  overrides: [
+    {
+      files: ["*.ts", "*.tsx"],
+      rules: {
+        "no-dupe-class-members": "off"
+      }
+    }
+  ]
 };


### PR DESCRIPTION
fix: unlocked TypeScript class methods overloading

Case described [here](https://github.com/typescript-eslint/typescript-eslint/issues/291).