### PR TITLE
IN-3365 Generate server/index.d.t.s \w typedefs for index.server.ts

### DIFF
--- a/packages/rollup-config/src/apiClient.ts
+++ b/packages/rollup-config/src/apiClient.ts
@@ -1,6 +1,7 @@
 import nodeResolve from '@rollup/plugin-node-resolve';
 import typescript from 'rollup-plugin-typescript2';
 import commonjs from '@rollup/plugin-commonjs';
+import { OutputBundle, OutputOptions } from 'rollup';
 
 const extensions = ['.ts', '.js'];
 // TODO add debug mode with advanced sourcemaps
@@ -29,7 +30,29 @@ export function generateServerConfig(pkg: any) {
       }),
       nodeResolve({
         extensions
-      })
+      }),
+      /**
+       * output: { file: pkg.server } in this file above always boils down to { file: 'server/index.js' }
+       *
+       * The output will be:
+       * - server/index.js (JS output of compiling index.server.ts, as per "output" property in this file)
+       * - server/index.d.ts (WRONG! This contains typedefs for the index.ts file, not the index.server.ts file)
+       * - server/index.server.d.ts (This contains typedefs for index.server.ts, but should be named index.d.ts to match the server/index.js file)
+       *
+       * The issue with the above outputs is that importing `@vsf-enterprise/someintegration-api/server` will throw errors,
+       * because you're using server/index.js with typedefs (server/index.d.ts) of a totally different file
+       */
+      {
+        name: "RemoveIndexTypedefMismatch",
+        generateBundle: (options: OutputOptions, bundle: OutputBundle) => {
+          // these files are for the src/index.ts file, not for src/index.server.ts, so we can remove them.
+          delete bundle["index.d.ts"];
+          delete bundle["index.d.ts.map"];
+          // The object keys being file names is just a decoration, the actual name of the output file is in the .fileName property
+          bundle["index.server.d.ts"].fileName = "index.d.ts";
+          bundle["index.server.d.ts.map"].fileName = "index.d.ts.map";
+        },
+      },
     ]
   };
 }


### PR DESCRIPTION
instead of typedefs for index.ts (mismatch)